### PR TITLE
fix(subtitles): avoid closing reused file descriptors

### DIFF
--- a/kinocut/engine_subtitles.py
+++ b/kinocut/engine_subtitles.py
@@ -58,12 +58,15 @@ def _fill_burn_source(fd: int, subtitle_format: str, subtitle_path: str, input_p
     """
     try:
         if subtitle_format == "ass":
-            with os.fdopen(fd, "wb") as dst, open(subtitle_path, "rb") as src:
-                shutil.copyfileobj(src, dst)
+            with os.fdopen(fd, "wb") as dst:
+                fd = -1  # The stream now owns closure, including source-open failures.
+                with open(subtitle_path, "rb") as src:
+                    shutil.copyfileobj(src, dst)
         else:
             width, height = probe_display_dimensions(input_path)
             content = synthesize_dimensioned_ass(subtitle_path, (width, height))
             with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                fd = -1
                 handle.write(content)
     except OSError as exc:
         raise MCPVideoError(
@@ -72,10 +75,11 @@ def _fill_burn_source(fd: int, subtitle_format: str, subtitle_path: str, input_p
             code="subtitle_prepare_failed",
         ) from exc
     finally:
-        # Own fd closure on every path; harmless (suppressed) after os.fdopen has
-        # already closed it, and essential when probe/synthesis raised first.
-        with contextlib.suppress(OSError):
-            os.close(fd)
+        # Close only while ownership has not transferred to a stream. Closing
+        # the old number again can close an unrelated, newly allocated file.
+        if fd >= 0:
+            with contextlib.suppress(OSError):
+                os.close(fd)
 
 
 def subtitles(

--- a/tests/test_subtitles_ass_and_dimension.py
+++ b/tests/test_subtitles_ass_and_dimension.py
@@ -503,6 +503,37 @@ def test_render_cli_forwards_style_and_defaults_none(monkeypatch):
     assert "style" not in captured  # omitted -> not forwarded (engine default None)
 
 
+@pytest.mark.parametrize("subtitle_format", ["ass", "srt"])
+def test_burn_source_does_not_close_a_reused_descriptor(monkeypatch, tmp_path, subtitle_format):
+    from kinocut import engine_subtitles
+
+    source = tmp_path / "source.ass"
+    source.write_text("[Script Info]\n", encoding="utf-8")
+    output = tmp_path / "burn.ass"
+    descriptor = os.open(output, os.O_CREAT | os.O_WRONLY, 0o600)
+    original_fdopen = os.fdopen
+    reused = []
+
+    @contextlib.contextmanager
+    def recycle_after_close(fd, *args, **kwargs):
+        with original_fdopen(fd, *args, **kwargs) as stream:
+            yield stream
+        replacement = os.open(tmp_path / "unrelated.txt", os.O_CREAT | os.O_WRONLY, 0o600)
+        reused.append(replacement)
+        assert replacement == fd
+
+    monkeypatch.setattr(engine_subtitles.os, "fdopen", recycle_after_close)
+    monkeypatch.setattr(engine_subtitles, "probe_display_dimensions", lambda _: (320, 240))
+    monkeypatch.setattr(engine_subtitles, "synthesize_dimensioned_ass", lambda *_: "[Script Info]\n")
+    try:
+        engine_subtitles._fill_burn_source(descriptor, subtitle_format, str(source), "unused.mp4")
+        assert os.write(reused[0], b"still owned by another operation") > 0
+    finally:
+        for fd in reused:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+
+
 def test_render_cli_subtitles_parser_has_style_flag():
     import argparse
 


### PR DESCRIPTION
Subtitle preparation transferred a temporary file descriptor to `os.fdopen`, then closed the same numeric descriptor again during cleanup. If another operation reused it after the stream closed, subtitle cleanup could close that operation's file.

Cleanup now relinquishes ownership when the stream takes it, while retaining cleanup for failures before transfer. Deterministic ASS and SRT regressions reproduce descriptor reuse and verify that the unrelated file stays writable.

Validation: independent review approved; focused cleanup checks passed; combined full suite with the sound-duration fix passed 5,591 tests, with 176 skipped; Ruff, formatting, compatibility import and diff checks passed. This fixes the proved ownership bug; the earlier intermittent missing-caption output remains unexplained.
