### PR TITLE
feat(sound): render explicit crossfades without shifting cues

### DIFF
--- a/docs/SOUND_CROSSFADES.md
+++ b/docs/SOUND_CROSSFADES.md
@@ -1,0 +1,36 @@
+# Explicit sound crossfades
+
+The Python mix renderer accepts `CrossfadeTransition` entries. Each entry
+permits the outgoing dialogue source's real post-roll to overlap the start
+of the adjacent incoming dialogue cue. Cue starts, nominal durations,
+incoming source alignment, and the authoritative episode duration stay fixed.
+
+```python
+from kinocut_sound.mix import CrossfadeTransition, MixRenderer
+
+result = MixRenderer().render(
+    timeline=timeline,
+    clips=clips,
+    transitions=(CrossfadeTransition("outgoing", "incoming", 0.02),),
+)
+```
+
+For a 20 ms transition, the outgoing WAV must contain at least 20 ms of real
+audio after its nominal cue duration. The incoming WAV must contain at least
+20 ms within its cue. Both sources must use the renderer's sample rate and
+the same stem. Source WAVs start at their respective cue's first sample.
+The transition applies the existing linear crossfade curve over the incoming
+cue's first 20 ms, quantized to whole samples. It does not shift later audio,
+repeat source samples to fabricate handles, or shorten the episode.
+
+Transitions across gaps, silence, chapter markers, incompatible stems, and
+missing handles fail with `mix_crossfade_invalid`. An incoming cue may have
+only one transition. Chained transitions use original source handles and
+produce the same output regardless of request ordering. Seam reports describe
+only blends actually applied, with the quantized duration.
+
+The legacy nonzero `crossfade_seconds` argument previously emitted a receipt
+without blending audio. It now fails with a migration message; replace it
+with explicit transitions and supply the required source handles. Zero keeps
+ordinary mixing unchanged. This API does not modify persisted SoundPlan
+records or extend the separate synthetic public adapter demo.

--- a/kinocut/engine_subtitles.py
+++ b/kinocut/engine_subtitles.py
@@ -58,12 +58,15 @@ def _fill_burn_source(fd: int, subtitle_format: str, subtitle_path: str, input_p
     """
     try:
         if subtitle_format == "ass":
-            with os.fdopen(fd, "wb") as dst, open(subtitle_path, "rb") as src:
-                shutil.copyfileobj(src, dst)
+            with os.fdopen(fd, "wb") as dst:
+                fd = -1  # The stream now owns closure, including source-open failures.
+                with open(subtitle_path, "rb") as src:
+                    shutil.copyfileobj(src, dst)
         else:
             width, height = probe_display_dimensions(input_path)
             content = synthesize_dimensioned_ass(subtitle_path, (width, height))
             with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                fd = -1
                 handle.write(content)
     except OSError as exc:
         raise MCPVideoError(
@@ -72,10 +75,11 @@ def _fill_burn_source(fd: int, subtitle_format: str, subtitle_path: str, input_p
             code="subtitle_prepare_failed",
         ) from exc
     finally:
-        # Own fd closure on every path; harmless (suppressed) after os.fdopen has
-        # already closed it, and essential when probe/synthesis raised first.
-        with contextlib.suppress(OSError):
-            os.close(fd)
+        # Close only while ownership has not transferred to a stream. Closing
+        # the old number again can close an unrelated, newly allocated file.
+        if fd >= 0:
+            with contextlib.suppress(OSError):
+                os.close(fd)
 
 
 def subtitles(

--- a/kinocut_sound/mix/__init__.py
+++ b/kinocut_sound/mix/__init__.py
@@ -21,6 +21,7 @@ from kinocut_sound.mix._errors import (
     mix_error,
 )
 from kinocut_sound.mix.crossfade import crossfade_pair
+from kinocut_sound.mix.transitions import CrossfadeTransition
 from kinocut_sound.mix.ducking import duck_bed_under_speech
 from kinocut_sound.mix.latency import compensate_latency
 from kinocut_sound.mix.placement import PlacedClip, PlacementPlan, place_clips
@@ -41,6 +42,7 @@ __all__ = [
     "MIX_PLACEMENT_INVALID",
     "MIX_STEM_RECOMBINE_FAILED",
     "MIX_UNSAFE_PATH",
+    "CrossfadeTransition",
     "MixClip",
     "MixError",
     "MixRenderer",

--- a/kinocut_sound/mix/renderer.py
+++ b/kinocut_sound/mix/renderer.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from array import array
 from dataclasses import dataclass
-from itertools import pairwise
 from math import isfinite
 
 from kinocut_sound.defaults import DEFAULT_GAP_TOLERANCE_SECONDS, DEFAULT_TAIL_SECONDS
@@ -12,6 +11,7 @@ from kinocut_sound.delivery import DeliveryPolicy, StemLayout
 from kinocut_sound.mix._errors import (
     MIX_DURATION_MISMATCH,
     MIX_INPUT_INVALID,
+    MIX_CROSSFADE_INVALID,
     MIX_UNSAFE_PATH,
     mix_error,
 )
@@ -22,7 +22,8 @@ from kinocut_sound.mix._wav import (
 )
 from kinocut_sound.mix.ducking import duck_bed_under_speech
 from kinocut_sound.mix.placement import PlacedClip, PlacementPlan, place_clips
-from kinocut_sound.mix.seam import SeamReport, SeamEvent
+from kinocut_sound.mix.seam import SeamReport
+from kinocut_sound.mix.transitions import CrossfadeTransition, apply_transitions
 from kinocut_sound.mix.stems import StemBundle, build_stem_bundle, recombine_stems
 from kinocut_sound.timeline import Timeline
 from kinocut_sound._canonical import location_violation
@@ -95,9 +96,16 @@ class MixRenderer:
         delivery: DeliveryPolicy | None = None,
         crossfade_seconds: float = 0.0,
         duck_bed: bool = False,
+        transitions: tuple[CrossfadeTransition, ...] = (),
     ) -> MixResult:
+        if isinstance(crossfade_seconds, bool) or crossfade_seconds != 0:
+            raise mix_error(
+                "use explicit CrossfadeTransition entries instead of crossfade_seconds", MIX_CROSSFADE_INVALID
+            )
         delivery = delivery or DeliveryPolicy()
         clip_map = {c.cue_id: c for c in clips}
+        if transitions and len(clip_map) != len(clips):
+            raise mix_error("transition sources must have unique cue ids", MIX_CROSSFADE_INVALID)
         durations = {c.cue_id: len(parse_wav(c.wav_bytes)[0]) / float(self.sample_rate_hz) for c in clips}
         stem_for = {c.cue_id: c.stem_id for c in clips}
         placement = place_clips(
@@ -113,23 +121,14 @@ class MixRenderer:
 
         stem_ids = delivery.stems.stem_ids or ("dialogue", "ambience", "sfx")
         canvases = {sid: _blank(total_samples) for sid in stem_ids}
-        seams: list[SeamEvent] = []
-
-        # Optional consecutive-line crossfade: preprocess ordered dialogue clips
         ordered = sorted(placement.placements, key=lambda p: p.start_seconds)
-        if crossfade_seconds > 0 and len(ordered) >= 2:
-            for left, right in pairwise(ordered):
-                if left.stem_id == right.stem_id == "dialogue" and left.cue_id in clip_map and right.cue_id in clip_map:
-                    # Only record seam; actual overlay uses truncated windows.
-                    seams.append(
-                        SeamEvent(
-                            kind="crossfade",
-                            at_seconds=right.start_seconds,
-                            left_cue_id=left.cue_id,
-                            right_cue_id=right.cue_id,
-                            duration_seconds=crossfade_seconds,
-                        )
-                    )
+        changed, seams = apply_transitions(
+            timeline, {c.cue_id: c.wav_bytes for c in clips}, stem_for, transitions, self.sample_rate_hz
+        )
+        for cue_id, wav_bytes in changed.items():
+            if clip_map[cue_id].stem_id not in canvases:
+                raise mix_error("transition stem must exist in delivery layout", MIX_CROSSFADE_INVALID)
+            clip_map[cue_id] = MixClip(cue_id, wav_bytes, clip_map[cue_id].stem_id)
 
         self._render_clips(ordered, clip_map, canvases, stem_ids)
         if bed_wav is not None:

--- a/kinocut_sound/mix/transitions.py
+++ b/kinocut_sound/mix/transitions.py
@@ -1,0 +1,94 @@
+"""Explicit post-roll crossfades that preserve authoritative cue positions."""
+
+from __future__ import annotations
+
+from array import array
+from dataclasses import dataclass
+from math import isfinite
+
+from kinocut_sound.mix._errors import MIX_CROSSFADE_INVALID, mix_error
+from kinocut_sound.mix._wav import parse_wav, pcm_to_wav
+from kinocut_sound.mix.crossfade import crossfade_pair
+from kinocut_sound.mix.seam import SeamEvent
+from kinocut_sound.timeline import CueKind, Timeline
+
+
+@dataclass(frozen=True)
+class CrossfadeTransition:
+    """Allow outgoing post-roll to overlap the beginning of an incoming cue.
+
+    Source WAVs start at their cue's first sample. The outgoing source must
+    contain real post-roll beyond its nominal duration. Both cues retain their
+    original start, duration and stem; the incoming source is never shifted.
+    """
+
+    outgoing_cue_id: str
+    incoming_cue_id: str
+    duration_seconds: float
+
+    def __post_init__(self) -> None:
+        value = self.duration_seconds
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or not isfinite(value) or value <= 0:
+            raise mix_error("transition duration must be positive and finite", MIX_CROSSFADE_INVALID)
+        if (
+            not isinstance(self.outgoing_cue_id, str)
+            or not isinstance(self.incoming_cue_id, str)
+            or not self.outgoing_cue_id
+            or not self.incoming_cue_id
+            or self.outgoing_cue_id == self.incoming_cue_id
+        ):
+            raise mix_error("transition requires two distinct cue ids", MIX_CROSSFADE_INVALID)
+
+
+def apply_transitions(
+    timeline: Timeline,
+    sources: dict[str, bytes],
+    stems: dict[str, str],
+    transitions: tuple[CrossfadeTransition, ...],
+    sample_rate_hz: int,
+) -> tuple[dict[str, bytes], list[SeamEvent]]:
+    """Return changed incoming sources and receipts for actual PCM blends."""
+    if not isinstance(transitions, tuple):
+        raise mix_error("transitions must be a tuple", MIX_CROSSFADE_INVALID)
+    changed: dict[str, bytes] = {}
+    events: list[SeamEvent] = []
+    positions = {cue.cue_id: i for i, cue in enumerate(timeline.cues)}
+    for transition in transitions:
+        if not isinstance(transition, CrossfadeTransition):
+            raise mix_error("transitions must be CrossfadeTransition instances", MIX_CROSSFADE_INVALID)
+        left_id, right_id = transition.outgoing_cue_id, transition.incoming_cue_id
+        left_pos, right_pos = positions.get(left_id), positions.get(right_id)
+        if left_pos is None or right_pos != left_pos + 1 or right_id in changed:
+            raise mix_error("transition must name unique adjacent cues", MIX_CROSSFADE_INVALID)
+        left, right = timeline.cues[left_pos], timeline.cues[right_pos]
+        if left.kind is not CueKind.LINE or right.kind is not CueKind.LINE:
+            raise mix_error("transitions require adjacent dialogue cues", MIX_CROSSFADE_INVALID)
+        if round(left.start_seconds * sample_rate_hz) + round(left.duration_seconds * sample_rate_hz) != round(
+            right.start_seconds * sample_rate_hz
+        ):
+            raise mix_error("transitions cannot cross timeline gaps", MIX_CROSSFADE_INVALID)
+        if stems.get(left_id) != stems.get(right_id) or left_id not in sources or right_id not in sources:
+            raise mix_error("transition sources must exist on the same stem", MIX_CROSSFADE_INVALID)
+        if transition.duration_seconds > right.duration_seconds:
+            raise mix_error("transition window must fit the incoming cue", MIX_CROSSFADE_INVALID)
+        fade_n = round(transition.duration_seconds * sample_rate_hz)
+        window_n = round(left.duration_seconds * sample_rate_hz)
+        if fade_n <= 0 or fade_n > round(right.duration_seconds * sample_rate_hz):
+            raise mix_error("transition window must fit the incoming cue", MIX_CROSSFADE_INVALID)
+        outgoing, left_rate = parse_wav(sources[left_id])
+        incoming, right_rate = parse_wav(sources[right_id])
+        if left_rate != sample_rate_hz or right_rate != sample_rate_hz:
+            raise mix_error("transition source sample rate mismatch", MIX_CROSSFADE_INVALID)
+        if len(outgoing) < window_n + fade_n or len(incoming) < fade_n:
+            raise mix_error("transition requires real outgoing post-roll and incoming samples", MIX_CROSSFADE_INVALID)
+        blended = crossfade_pair(
+            pcm_to_wav(outgoing[window_n : window_n + fade_n], sample_rate_hz=sample_rate_hz),
+            pcm_to_wav(incoming[:fade_n], sample_rate_hz=sample_rate_hz),
+            fade_seconds=fade_n / sample_rate_hz,
+        )
+        updated = array("h", incoming)
+        updated[:fade_n] = parse_wav(blended)[0]
+        changed[right_id] = pcm_to_wav(updated, sample_rate_hz=sample_rate_hz)
+        at_seconds = round(right.start_seconds * sample_rate_hz) / sample_rate_hz
+        events.append(SeamEvent("crossfade", at_seconds, left_id, right_id, fade_n / sample_rate_hz))
+    return changed, sorted(events, key=lambda event: event.at_seconds)

--- a/tests/test_kinocut_sound_mix.py
+++ b/tests/test_kinocut_sound_mix.py
@@ -136,14 +136,13 @@ def test_mix_renderer_duration_proof_and_stems():
         clips=clips,
         bed_wav=bed,
         delivery=DeliveryPolicy(stems=StemLayout(stem_ids=("dialogue", "ambience", "sfx"))),
-        crossfade_seconds=0.05,
         duck_bed=True,
     )
     assert result.within_tolerance is True
     assert result.measured_duration_seconds == pytest.approx(result.declared_duration_seconds, abs=0.02)
     assert result.declared_duration_seconds >= 1.4
     assert set(result.stems.stems) >= {"dialogue", "ambience", "sfx"}
-    assert result.seam_report.count >= 1
+    assert result.seam_report.count == 0  # Intentional silence is not a crossfade.
 
 
 @pytest.mark.parametrize("renderer_tail", [0.0, 0.1])

--- a/tests/test_sound_crossfade_transitions.py
+++ b/tests/test_sound_crossfade_transitions.py
@@ -1,0 +1,158 @@
+"""PCM and timing proofs for explicit outgoing post-roll transitions."""
+
+from array import array
+
+import pytest
+
+from kinocut_sound.mix import CrossfadeTransition, MixClip, MixError, MixRenderer, recombine_stems
+from kinocut_sound.mix._wav import parse_wav, pcm_to_wav
+from kinocut_sound.timeline import Cue, CueKind, Timeline
+
+RATE = 1000
+
+
+def _wav(samples):
+    return pcm_to_wav(array("h", samples), sample_rate_hz=RATE)
+
+
+def _fixture():
+    timeline = Timeline(
+        cues=tuple(
+            Cue(cue_id=name, start_seconds=start, duration_seconds=0.1, kind=CueKind.LINE, source_ref=f"v/{name}.wav")
+            for name, start in (("a", 0.0), ("b", 0.1), ("c", 0.2))
+        ),
+        tail_seconds=0.05,
+    )
+    clips = (
+        MixClip("a", _wav([1000] * 100 + [8000] * 20)),
+        MixClip("b", _wav([-8000] * 20 + list(range(80)) + [4000] * 20)),
+        MixClip("c", _wav([-4000] * 100)),
+    )
+    return timeline, clips
+
+
+def test_crossfade_changes_only_explicit_windows_and_preserves_sources():
+    timeline, clips = _fixture()
+    renderer = MixRenderer(sample_rate_hz=RATE)
+    plain = renderer.render(timeline=timeline, clips=clips)
+    transitions = (CrossfadeTransition("a", "b", 0.02), CrossfadeTransition("b", "c", 0.02))
+    result = renderer.render(timeline=timeline, clips=clips, transitions=transitions)
+    samples, _ = parse_wav(result.master_wav)
+    original, _ = parse_wav(plain.master_wav)
+    assert samples[:100] == original[:100]
+    assert samples[120:200] == original[120:200]
+    assert samples[220:] == original[220:]
+    assert samples[100] == 8000 and samples[110] == 0 and samples[119] < -7000
+    assert samples[200] == 4000 and samples[210] == 0
+    assert len(samples) == 350 and not any(samples[300:])
+    assert result.measured_duration_seconds == 0.35
+    assert result.declared_duration_seconds == pytest.approx(0.35)
+    assert result.master_wav == recombine_stems(result.stems)
+    assert (
+        result.master_wav == renderer.render(timeline=timeline, clips=clips, transitions=transitions[::-1]).master_wav
+    )
+    assert [(event.at_seconds, event.duration_seconds) for event in result.seam_report.events] == [
+        (0.1, 0.02),
+        (0.2, 0.02),
+    ]
+    assert parse_wav(clips[0].wav_bytes)[0][100] == 8000
+
+
+@pytest.mark.parametrize("duration", [-1, 0, float("nan"), float("inf"), True, None, "0.02"])
+def test_invalid_transition_duration_fails_closed(duration):
+    with pytest.raises(MixError, match="positive and finite"):
+        CrossfadeTransition("a", "b", duration)
+
+
+@pytest.mark.parametrize("legacy", [0.02, -1, float("nan"), float("inf"), True, None])
+def test_legacy_scalar_cannot_emit_unrendered_receipts(legacy):
+    timeline, clips = _fixture()
+    with pytest.raises(MixError, match="explicit CrossfadeTransition"):
+        MixRenderer(sample_rate_hz=RATE).render(timeline=timeline, clips=clips, crossfade_seconds=legacy)
+
+
+@pytest.mark.parametrize(
+    "transition",
+    [
+        CrossfadeTransition("a", "c", 0.02),
+        CrossfadeTransition("absent", "b", 0.02),
+        CrossfadeTransition("a", "b", 0.2),
+        CrossfadeTransition("a", "b", 0.0001),
+    ],
+)
+def test_invalid_transition_window_fails_closed(transition):
+    timeline, clips = _fixture()
+    with pytest.raises(MixError):
+        MixRenderer(sample_rate_hz=RATE).render(timeline=timeline, clips=clips, transitions=(transition,))
+
+
+@pytest.mark.parametrize("problem", ["postroll", "incoming", "stem", "rate", "duplicate", "duplicate_source", "layout"])
+def test_incomplete_or_conflicting_sources_fail_closed(problem):
+    timeline, clips = _fixture()
+    clips = list(clips)
+    transitions = (CrossfadeTransition("a", "b", 0.02),)
+    if problem == "postroll":
+        clips[0] = MixClip("a", _wav([1000] * 100))
+    elif problem == "incoming":
+        clips[1] = MixClip("b", _wav([1000] * 10))
+    elif problem == "stem":
+        clips[1] = MixClip("b", clips[1].wav_bytes, "sfx")
+    elif problem == "rate":
+        clips[0] = MixClip("a", pcm_to_wav(array("h", [1000] * 120), sample_rate_hz=2000))
+    elif problem == "duplicate_source":
+        clips.append(clips[0])
+    elif problem == "layout":
+        clips = [MixClip(clip.cue_id, clip.wav_bytes, "unlisted") for clip in clips]
+    else:
+        transitions *= 2
+    with pytest.raises(MixError):
+        MixRenderer(sample_rate_hz=RATE).render(timeline=timeline, clips=tuple(clips), transitions=transitions)
+
+
+@pytest.mark.parametrize("kind", [CueKind.SILENCE, CueKind.CHAPTER_MARKER])
+def test_transitions_cannot_cross_designed_silence_or_markers(kind):
+    timeline, clips = _fixture()
+    middle = timeline.cues[1].model_copy(update={"kind": kind})
+    timeline = Timeline(cues=(timeline.cues[0], middle, timeline.cues[2]))
+    used_clips = (clips[0], clips[2])
+    plain = MixRenderer(sample_rate_hz=RATE).render(timeline=timeline, clips=used_clips)
+    assert not any(parse_wav(plain.master_wav)[0][100:200])
+    with pytest.raises(MixError):
+        MixRenderer(sample_rate_hz=RATE).render(
+            timeline=timeline, clips=used_clips, transitions=(CrossfadeTransition("a", "c", 0.02),)
+        )
+
+
+def test_crossfade_cannot_fill_an_allowed_timeline_gap():
+    timeline, clips = _fixture()
+    second = timeline.cues[1].model_copy(update={"start_seconds": 0.105, "duration_seconds": 0.095})
+    timeline = Timeline(cues=(timeline.cues[0], second, timeline.cues[2]))
+    with pytest.raises(MixError, match="gaps"):
+        MixRenderer(sample_rate_hz=RATE).render(
+            timeline=timeline, clips=clips, transitions=(CrossfadeTransition("a", "b", 0.02),)
+        )
+
+
+@pytest.mark.parametrize("start,duration,incoming", [(0.0006, 0.1006, 0.1012), (0.0004, 0.1004, 0.1008)])
+def test_fractional_boundaries_cannot_overlap_or_gap_in_sample_space(start, duration, incoming):
+    timeline, clips = _fixture()
+    left = timeline.cues[0].model_copy(update={"start_seconds": start, "duration_seconds": duration})
+    right = timeline.cues[1].model_copy(update={"start_seconds": incoming})
+    timeline = Timeline(cues=(left, right))
+    with pytest.raises(MixError, match="gaps"):
+        MixRenderer(sample_rate_hz=RATE).render(
+            timeline=timeline, clips=clips[:2], transitions=(CrossfadeTransition("a", "b", 0.02),)
+        )
+
+
+def test_receipt_uses_actual_sample_boundary_without_changing_logical_cues():
+    timeline, clips = _fixture()
+    left = timeline.cues[0].model_copy(update={"start_seconds": 0.0004})
+    right = timeline.cues[1].model_copy(update={"start_seconds": 0.1004})
+    timeline = Timeline(cues=(left, right))
+    result = MixRenderer(sample_rate_hz=RATE).render(
+        timeline=timeline, clips=clips[:2], transitions=(CrossfadeTransition("a", "b", 0.02),)
+    )
+    assert result.seam_report.events[0].at_seconds == 0.1
+    assert parse_wav(result.master_wav)[0][100] == 8000
+    assert timeline.cues[1].start_seconds == 0.1004

--- a/tests/test_subtitles_ass_and_dimension.py
+++ b/tests/test_subtitles_ass_and_dimension.py
@@ -503,6 +503,37 @@ def test_render_cli_forwards_style_and_defaults_none(monkeypatch):
     assert "style" not in captured  # omitted -> not forwarded (engine default None)
 
 
+@pytest.mark.parametrize("subtitle_format", ["ass", "srt"])
+def test_burn_source_does_not_close_a_reused_descriptor(monkeypatch, tmp_path, subtitle_format):
+    from kinocut import engine_subtitles
+
+    source = tmp_path / "source.ass"
+    source.write_text("[Script Info]\n", encoding="utf-8")
+    output = tmp_path / "burn.ass"
+    descriptor = os.open(output, os.O_CREAT | os.O_WRONLY, 0o600)
+    original_fdopen = os.fdopen
+    reused = []
+
+    @contextlib.contextmanager
+    def recycle_after_close(fd, *args, **kwargs):
+        with original_fdopen(fd, *args, **kwargs) as stream:
+            yield stream
+        replacement = os.open(tmp_path / "unrelated.txt", os.O_CREAT | os.O_WRONLY, 0o600)
+        reused.append(replacement)
+        assert replacement == fd
+
+    monkeypatch.setattr(engine_subtitles.os, "fdopen", recycle_after_close)
+    monkeypatch.setattr(engine_subtitles, "probe_display_dimensions", lambda _: (320, 240))
+    monkeypatch.setattr(engine_subtitles, "synthesize_dimensioned_ass", lambda *_: "[Script Info]\n")
+    try:
+        engine_subtitles._fill_burn_source(descriptor, subtitle_format, str(source), "unused.mp4")
+        assert os.write(reused[0], b"still owned by another operation") > 0
+    finally:
+        for fd in reused:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+
+
 def test_render_cli_subtitles_parser_has_style_flag():
     import argparse
 


### PR DESCRIPTION
`MixRenderer` previously emitted crossfade seam receipts without changing audio. It now accepts explicit `CrossfadeTransition` entries that blend real outgoing post-roll with the incoming cue's first samples. Cue timing, incoming source alignment, silence, stems and authoritative output duration are preserved.

Transitions fail closed for missing source handles, gaps, silence/markers, incompatible or missing stems, duplicate sources/transitions, invalid durations and inconsistent sample boundaries. Receipts report actual quantized blend windows. Nonzero legacy `crossfade_seconds` now raises migration guidance instead of reporting an operation that never happened.

This extends the Python renderer API. Persisted SoundPlan records and the separate synthetic CLI/MCP demo remain unchanged. Usage and source-handle requirements are documented in `docs/SOUND_CROSSFADES.md`.

Validation: final combined full suite passed 5,622 tests with 176 skipped; 51 focused tests pass, including real PCM blends, unchanged samples outside transition windows, deterministic chained transitions, exact silence and total sample counts, stem recombination, and fractional-sample boundary regressions. Independent review approved the corrected source; Ruff, touched-file formatting, size checks, compatibility imports and added-line leak checks pass.
