### PR TITLE
fix(sound): accept adjacent cues despite float roundoff

### DIFF
--- a/kinocut_sound/timeline.py
+++ b/kinocut_sound/timeline.py
@@ -14,6 +14,7 @@ Design references (sonic-world design):
 from __future__ import annotations
 
 from enum import StrEnum
+from math import inf, nextafter
 
 from pydantic import Field, field_validator, model_validator
 
@@ -86,6 +87,8 @@ class Timeline(FrozenModel):
     The timeline total (last cue end + tail) is the authoritative required
     output duration. An unexplained gap between cues larger than the configured
     tolerance is rejected as a prohibited shortest-stream mix.
+    Boundary comparisons allow one representable float step for arithmetic
+    roundoff; this does not apply the gap tolerance to overlapping cues.
     """
 
     cues: tuple[Cue, ...] = ()
@@ -118,11 +121,11 @@ class Timeline(FrozenModel):
             if cue.cue_id in seen_ids:
                 raise ValueError(f"duplicate cue_id: {cue.cue_id}")
             seen_ids.add(cue.cue_id)
-            # Allow exact adjacency (start == last_end) but reject going back.
-            if cue.start_seconds < last_end:
+            # Addition can put a decimal boundary one float step past its cue.
+            if cue.start_seconds < nextafter(last_end, -inf):
                 raise ValueError(f"cue {cue.cue_id} starts before previous cue ends")
             gap = cue.start_seconds - last_end
-            if gap > self.gap_tolerance_seconds:
+            if cue.start_seconds > nextafter(last_end + self.gap_tolerance_seconds, inf):
                 raise ValueError(
                     f"cue {cue.cue_id} opens an unexplained gap of {gap:.3f}s "
                     f"(tolerance {self.gap_tolerance_seconds:.3f}s)"

--- a/tests/test_sound_timeline_roundoff.py
+++ b/tests/test_sound_timeline_roundoff.py
@@ -1,0 +1,43 @@
+"""Adjacent decimal cue boundaries must survive binary float arithmetic."""
+
+from math import inf, nextafter
+
+import pytest
+from pydantic import ValidationError
+
+from kinocut_sound.mix import MixClip, MixRenderer
+from kinocut_sound.mix._wav import parse_wav, synthesize_tone
+from kinocut_sound.timeline import Cue, CueKind, Timeline
+
+
+def _cue(name, start, duration):
+    return Cue(
+        cue_id=name, start_seconds=start, duration_seconds=duration, kind=CueKind.LINE, source_ref=f"v/{name}.wav"
+    )
+
+
+def test_four_adjacent_decimal_cues_render_without_false_overlap():
+    timeline = Timeline(cues=tuple(_cue(f"line_{i}", i / 10, 0.1) for i in range(4)), gap_tolerance_seconds=0)
+    wav = synthesize_tone(duration_seconds=0.1)
+    result = MixRenderer().render(timeline=timeline, clips=tuple(MixClip(cue.cue_id, wav) for cue in timeline.cues))
+    samples, rate = parse_wav(result.master_wav)
+    assert len(samples) == round(0.4 * rate)
+    assert result.measured_duration_seconds == 0.4
+    assert result.within_tolerance
+
+
+def test_gap_at_declared_tolerance_survives_subtraction_roundoff():
+    timeline = Timeline(cues=(_cue("a", 0, 0.29), _cue("b", 0.30, 0.1)), gap_tolerance_seconds=0.01)
+    assert timeline.cues[1].start_seconds == 0.30
+
+
+@pytest.mark.parametrize("start", [0.299, nextafter(nextafter(0.3, -inf), -inf)])
+def test_overlap_beyond_one_float_step_is_rejected(start):
+    with pytest.raises(ValidationError, match="before previous cue ends"):
+        Timeline(cues=(_cue("a", 0, 0.3), _cue("b", start, 0.1)))
+
+
+@pytest.mark.parametrize("start", [0.30001, nextafter(nextafter(0.29 + 0.01, inf), inf)])
+def test_gap_beyond_one_float_step_is_rejected(start):
+    with pytest.raises(ValidationError, match="unexplained gap"):
+        Timeline(cues=(_cue("a", 0, 0.29), _cue("b", start, 0.1)), gap_tolerance_seconds=0.01)


### PR DESCRIPTION
Four adjacent 0.1-second sound cues were rejected as overlapping because binary floating-point addition placed the third cue's end just beyond 0.3. A gap exactly at its configured tolerance could fail for the same reason.

Timeline boundary comparisons now allow one representable floating-point step for arithmetic rounding. Stored cue times and record serialization stay unchanged, and overlap validation remains separate from the configured gap tolerance. Regressions prove a four-cue sequence renders to the exact sample count and that larger overlaps and gaps remain rejected.

Independent review approved; full combined suite passed 5,628 tests with 176 skipped. The 66 focused tests cover existing timeline contracts, the new regressions, crossfades and mixing. Ruff, formatting, compatibility imports and diff checks passed.
