### PR TITLE
feat(sound): render source windows and preserve additive ambience

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -109,7 +109,7 @@ Published surface (since 1.14.1; current 1.15.1). These commands do **not** add 
 | `sound-capabilities` | Discover the bounded public sound operation set |
 | `sound-plan-validate` | Validate a SoundPlan JSON payload (`--plan-json` optional) |
 | `sound-voice-batch` | Retained local caption speech (`--request-json`, `--project-root`); legacy synthetic demo (`--plan-json` optional). See [caption speech](SOUND_DUB_REQUESTS.md). |
-| `sound-mix-render` | Supplied-media mix ZIP via `--request-json` and `--project-root`; omit both for a labelled demo. See [request contract](SOUND_MIX_REQUESTS.md). |
+| `sound-mix-render` | Supplied-media mix ZIP with cue source windows and additive ducked ambience via `--request-json` and `--project-root`; omit both for a labelled demo. See [request contract](SOUND_MIX_REQUESTS.md). |
 | `sound-qa-loudness` | Loudness check against the default delivery policy |
 | `sound-qa-asr` | Fake ASR verification (`--script-hashes`, `--audio-duration-seconds`) |
 

--- a/docs/SOUND_MIX_REQUESTS.md
+++ b/docs/SOUND_MIX_REQUESTS.md
@@ -42,8 +42,9 @@ Its `schema_version` is integer `1` and unknown fields are rejected.
 Asset hashes use `sha256:<lowercase hex>`. A clip path must equal its cue's
 `source_ref`; each audible cue has exactly one binding. Silence and chapter
 markers have no clip binding. Stems must be declared by the delivery layout;
-an empty layout selects dialogue, ambience and sfx. A bed requires its own
-ambience stem, with no competing ambience clip.
+an empty layout selects dialogue, ambience and sfx. A bed requires a declared
+ambience stem. Ambience clips and the separate bed are added together with
+PCM16 saturation. Ducking affects only the bed, preserving the ambience clips.
 
 Crossfades use actual outgoing post-roll and preserve incoming cue timing, as
 described in [Sound crossfades](SOUND_CROSSFADES.md). Persisting a crossfade in
@@ -55,8 +56,21 @@ hashes the complete ZIP, avoiding a circular hash.
 ## Current rendering capabilities
 
 Assembly supports mono signed 16-bit PCM, a shared sample rate from 8–96 kHz,
-continuous time, explicit silence/tail, named stems and post-roll crossfades.
-It rejects cue trim fields, `transit_kind`, nondefault routing, layers, format
+continuous time, explicit silence/tail, named stems, source windows and post-roll
+crossfades. Cue `in_point_seconds` is inclusive (default zero), while
+`out_point_seconds` is exclusive (default source end). Seconds quantize with
+`round(seconds * sample_rate_hz)`. Out-of-range seconds and empty quantized
+windows fail instead of clamping. Silence and chapter markers cannot select
+source windows. Several cues may select different windows of one source file.
+
+Selected samples are prepared once before crossfades and placement. Short
+selections are padded with silence to the cue duration; longer ones are truncated
+to that duration. Crossfades require actual post-roll inside the selected window,
+including its out-point. The receipt's `source_windows` records cue ID, in/out
+sample positions, selected count and rate; source hashes still bind the original
+whole file. These fields preserve existing SoundPlan identity semantics.
+
+Assembly rejects `transit_kind`, nondefault routing, layers, format
 conversion and dither until those rendering paths are implemented. It does not
 silently discard those requests. Declared delivery targets are retained as plan
 intent, not reported as achieved mastering. Full episode listening and complete

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -301,7 +301,7 @@ Bounded local-first sound discovery and invoke via `kinocut_sound.public`. This 
 | `sound_capabilities` | Discover the bounded public sound operation set (local-first, non-TTY JSON) |
 | `sound_plan_validate` | Validate a SoundPlan payload (or a built-in minimal plan when omitted) |
 | `sound_voice_batch` | Retain local EN/ES caption speech with `request` + `project_root`; legacy `plan` mode is a labelled synthetic demo. See [caption speech](SOUND_DUB_REQUESTS.md). |
-| `sound_mix_render` | Assemble supplied WAVs from a persisted request and project root into a verified ZIP; no-argument labelled demo remains available. See [request contract](SOUND_MIX_REQUESTS.md). |
+| `sound_mix_render` | Assemble supplied WAVs with cue source windows, crossfades and additive ducked ambience into a verified ZIP; takes a persisted request and project root. No-argument labelled demo remains available. See [request contract](SOUND_MIX_REQUESTS.md). |
 | `sound_qa_loudness` | Measure loudness against the default delivery policy on synthetic audio |
 | `sound_qa_asr` | Run the local fake ASR verification port against script hashes |
 

--- a/kinocut_sound/mix/renderer.py
+++ b/kinocut_sound/mix/renderer.py
@@ -23,6 +23,7 @@ from kinocut_sound.mix._wav import (
 from kinocut_sound.mix.ducking import duck_bed_under_speech
 from kinocut_sound.mix.placement import PlacedClip, PlacementPlan, place_clips
 from kinocut_sound.mix.seam import SeamReport
+from kinocut_sound.mix.source_windows import SourceWindow, select_source_windows
 from kinocut_sound.mix.transitions import CrossfadeTransition, apply_transitions
 from kinocut_sound.mix.stems import StemBundle, build_stem_bundle, recombine_stems
 from kinocut_sound.timeline import Timeline
@@ -49,6 +50,7 @@ class MixResult:
     within_tolerance: bool
     seam_report: SeamReport
     placement: PlacementPlan
+    source_windows: tuple[SourceWindow, ...] = ()
 
 
 def _blank(length: int) -> array:
@@ -106,6 +108,9 @@ class MixRenderer:
         clip_map = {c.cue_id: c for c in clips}
         if transitions and len(clip_map) != len(clips):
             raise mix_error("transition sources must have unique cue ids", MIX_CROSSFADE_INVALID)
+        selected, windows = select_source_windows(timeline, {c.cue_id: c.wav_bytes for c in clips}, self.sample_rate_hz)
+        clips = tuple(MixClip(c.cue_id, selected[c.cue_id], c.stem_id) for c in clips)
+        clip_map = {c.cue_id: c for c in clips}
         durations = {c.cue_id: len(parse_wav(c.wav_bytes)[0]) / float(self.sample_rate_hz) for c in clips}
         stem_for = {c.cue_id: c.stem_id for c in clips}
         placement = place_clips(
@@ -153,6 +158,7 @@ class MixRenderer:
             within_tolerance=within,
             seam_report=SeamReport(events=tuple(seams)),
             placement=placement,
+            source_windows=windows,
         )
 
     def _render_clips(
@@ -190,7 +196,9 @@ class MixRenderer:
             _overlay(bed_canvas, bed_samples, 0)
             bed_full = pcm_to_wav(bed_canvas, sample_rate_hz=self.sample_rate_hz)
             ducked = duck_bed_under_speech(speech, bed_full)
-            canvases["ambience"] = parse_wav(ducked)[0]
+            if "ambience" not in canvases:
+                canvases["ambience"] = _blank(total_samples)
+            _overlay(canvases["ambience"], parse_wav(ducked)[0], 0)
         else:
             if "ambience" not in canvases:
                 canvases["ambience"] = _blank(total_samples)

--- a/kinocut_sound/mix/source_windows.py
+++ b/kinocut_sound/mix/source_windows.py
@@ -1,0 +1,50 @@
+"""Select source PCM once before timeline placement and post-roll transitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from kinocut_sound.mix._errors import MIX_INPUT_INVALID, mix_error
+from kinocut_sound.mix._wav import parse_wav, pcm_to_wav
+from kinocut_sound.timeline import CueKind, Timeline
+
+
+@dataclass(frozen=True)
+class SourceWindow:
+    cue_id: str
+    in_sample: int
+    out_sample: int
+    sample_count: int
+    sample_rate_hz: int
+
+
+def select_source_windows(
+    timeline: Timeline,
+    sources: dict[str, bytes],
+    sample_rate_hz: int,
+) -> tuple[dict[str, bytes], tuple[SourceWindow, ...]]:
+    selected = dict(sources)
+    proofs = []
+    for cue in timeline.cues:
+        trimmed = cue.in_point_seconds is not None or cue.out_point_seconds is not None
+        if cue.kind in (CueKind.SILENCE, CueKind.CHAPTER_MARKER):
+            if trimmed:
+                raise mix_error("silent cues cannot select source windows", MIX_INPUT_INVALID)
+            continue
+        if cue.cue_id not in sources:
+            raise mix_error("source window requires its cue source", MIX_INPUT_INVALID)
+        samples, rate = parse_wav(sources[cue.cue_id])
+        if rate != sample_rate_hz:
+            raise mix_error("clip sample rate mismatch", MIX_INPUT_INVALID)
+        duration = len(samples) / rate
+        start = cue.in_point_seconds if cue.in_point_seconds is not None else 0
+        end = cue.out_point_seconds if cue.out_point_seconds is not None else duration
+        if start >= duration or end > duration or end <= start:
+            raise mix_error("source window lies outside source duration", MIX_INPUT_INVALID)
+        first, last = round(start * rate), round(end * rate)
+        if first < 0 or last > len(samples) or first >= last:
+            raise mix_error("source window must select actual samples", MIX_INPUT_INVALID)
+        if trimmed:
+            selected[cue.cue_id] = pcm_to_wav(samples[first:last], sample_rate_hz=rate)
+        proofs.append(SourceWindow(cue.cue_id, first, last, last - first, rate))
+    return selected, tuple(proofs)

--- a/kinocut_sound/public/mix_request.py
+++ b/kinocut_sound/public/mix_request.py
@@ -150,8 +150,14 @@ def validate_supported_intent(request: SoundMixRequest) -> None:
     cues = plan.timeline.cues
     if not cues or len(cues) > MAX_ASSEMBLY_CLIPS:
         raise mix_error("mix requires a bounded nonempty timeline", MIX_OVER_LIMIT)
-    if any(c.in_point_seconds is not None or c.out_point_seconds is not None or c.transit_kind for c in cues):
-        raise mix_error("cue trims and transit_kind are not implemented by mix assembly", "mix_unsupported_intent")
+    if any(c.transit_kind for c in cues):
+        raise mix_error("transit_kind is not implemented by mix assembly", "mix_unsupported_intent")
+    if any(
+        c.kind in (CueKind.SILENCE, CueKind.CHAPTER_MARKER)
+        and (c.in_point_seconds is not None or c.out_point_seconds is not None)
+        for c in cues
+    ):
+        raise mix_error("silent cues cannot select source windows", MIX_INPUT_INVALID)
     audible = {c.cue_id: c for c in cues if c.kind not in (CueKind.SILENCE, CueKind.CHAPTER_MARKER)}
     bindings = {c.cue_id: c for c in request.clips}
     if len(bindings) != len(request.clips) or set(bindings) != set(audible):
@@ -167,8 +173,8 @@ def validate_supported_intent(request: SoundMixRequest) -> None:
         raise mix_error("mix bed must match the plan bed reference", MIX_INPUT_INVALID)
     if request.duck_bed and "dialogue" not in stems:
         raise mix_error("bed ducking requires a declared dialogue stem", "mix_unsupported_intent")
-    if request.bed and ("ambience" not in stems or any(c.stem_id == "ambience" for c in request.clips)):
-        raise mix_error("bed requires its own declared ambience stem", "mix_unsupported_intent")
+    if request.bed and "ambience" not in stems:
+        raise mix_error("bed requires a declared ambience stem", "mix_unsupported_intent")
     check_mix_resources(request, 0)
 
 

--- a/kinocut_sound/public/mix_worker.py
+++ b/kinocut_sound/public/mix_worker.py
@@ -65,6 +65,7 @@ def _write_bundle(output_fd, request, result):
         "sources": [c.model_dump(mode="json") for c in request.clips],
         "bed": request.bed.model_dump(mode="json") if request.bed else None,
         "seams": [asdict(event) for event in result.seam_report.events],
+        "source_windows": [asdict(window) for window in result.source_windows],
     }
     members["receipt.json"] = json.dumps(receipt, sort_keys=True, separators=(",", ":")).encode()
     with os.fdopen(os.dup(output_fd), "wb") as target:

--- a/skills/kinocut/SKILL.md
+++ b/skills/kinocut/SKILL.md
@@ -168,6 +168,7 @@ Receipts store workspace-relative paths only — keep specs and example receipts
    - For thin sound: `sound-capabilities` then `sound-plan-validate` / `sound-voice-batch` / `sound-mix-render` / `sound-qa-loudness` / `sound-qa-asr` (or `kino sound <action>`).
    - For actual local EN/ES caption speech, supply a hashed `SoundDubRequest` and explicit project root to `sound-voice-batch`; see `docs/SOUND_DUB_REQUESTS.md`. This optional eSpeak NG path retains WAVs and a mix request. It does not translate, clone voices or apply mastering; legacy plan mode remains a labelled synthetic demo.
    - For supplied-media mixing, pass a persisted request plus explicit project root to `sound_mix_render`, or use `sound-mix-render --request-json request.json --project-root .`. Verify the ZIP receipt and decoded media; assembly is not loudness mastering or human listening acceptance. See `docs/SOUND_MIX_REQUESTS.md` for format, filesystem, cancellation and resource limits.
+   - Cue in/out points select source samples before placement and crossfades; post-roll must remain inside that selection. Verify `source_windows` in the receipt. A ducked bed adds to existing ambience clips.
 4. Produce release artifacts before publishing:
    - `video-quality-check`
    - `storyboard` or `thumbnail`

--- a/tests/test_sound_source_windows.py
+++ b/tests/test_sound_source_windows.py
@@ -1,0 +1,144 @@
+"""Real source-window and additive-bed behavior at the renderer boundary."""
+
+from array import array
+
+import pytest
+
+from kinocut_sound.mix import CrossfadeTransition, MixClip, MixRenderer
+from kinocut_sound.mix._errors import MixError
+from kinocut_sound.mix._wav import parse_wav, pcm_to_wav
+from kinocut_sound.timeline import Cue, CueKind, Timeline
+
+
+def _wave(values):
+    return pcm_to_wav(array("h", values), sample_rate_hz=8000)
+
+
+def _cue(name="a", start=0, duration=0.001, **kwargs):
+    return Cue(
+        cue_id=name,
+        source_ref="source.wav",
+        start_seconds=start,
+        duration_seconds=duration,
+        kind=CueKind.LINE,
+        **kwargs,
+    )
+
+
+def test_exact_window_padding_tail_and_receipt():
+    cue = _cue(in_point_seconds=0.00025, out_point_seconds=0.00075)
+    result = MixRenderer(sample_rate_hz=8000).render(
+        timeline=Timeline(cues=(cue,), tail_seconds=0.00025),
+        clips=(MixClip("a", _wave(range(100, 110))),),
+    )
+    assert list(parse_wav(result.master_wav)[0]) == [102, 103, 104, 105, 0, 0, 0, 0, 0, 0]
+    proof = result.source_windows[0]
+    assert (proof.in_sample, proof.out_sample, proof.sample_count, proof.sample_rate_hz) == (2, 6, 4, 8000)
+
+
+@pytest.mark.parametrize(
+    "points",
+    [
+        {"in_point_seconds": 0.001},
+        {"out_point_seconds": 0.00100000001},
+        {"in_point_seconds": 0.00001, "out_point_seconds": 0.00002},
+    ],
+)
+def test_invalid_window_does_not_clamp_or_round_back_inside(points):
+    with pytest.raises(MixError):
+        MixRenderer(sample_rate_hz=8000).render(
+            timeline=Timeline(cues=(_cue(**points),)),
+            clips=(MixClip("a", _wave(range(8))),),
+        )
+
+
+def test_crossfade_cannot_use_postroll_outside_selected_window():
+    left = _cue(out_point_seconds=0.001)
+    right = _cue("b", 0.001)
+    with pytest.raises(MixError, match="post-roll"):
+        MixRenderer(sample_rate_hz=8000).render(
+            timeline=Timeline(cues=(left, right)),
+            clips=(MixClip("a", _wave([200] * 16)), MixClip("b", _wave([-100] * 8))),
+            transitions=(CrossfadeTransition("a", "b", 0.0005),),
+        )
+
+
+@pytest.mark.parametrize("duck", [False, True])
+def test_bed_preserves_ambience_sentinel(duck):
+    cue = _cue()
+    result = MixRenderer(sample_rate_hz=8000).render(
+        timeline=Timeline(cues=(cue,)),
+        clips=(MixClip("a", _wave([123] * 8), "ambience"),),
+        bed_wav=_wave([200] * 8),
+        duck_bed=duck,
+    )
+    assert list(parse_wav(result.stems.stems["ambience"])[0]) == [323] * 8
+
+
+def test_additive_bed_saturates_without_wrapping():
+    result = MixRenderer(sample_rate_hz=8000).render(
+        timeline=Timeline(cues=(_cue(),)),
+        clips=(MixClip("a", _wave([30000] * 8), "ambience"),),
+        bed_wav=_wave([10000] * 8),
+        duck_bed=True,
+    )
+    assert list(parse_wav(result.stems.stems["ambience"])[0]) == [32767] * 8
+
+
+def test_speech_ducks_only_bed_while_later_ambience_survives():
+    timeline = Timeline(cues=(_cue(duration=0.1), _cue("b", 0.1, 0.1)))
+    clips = (MixClip("a", _wave([10000] * 800)), MixClip("b", _wave([123] * 800), "ambience"))
+    result = MixRenderer(sample_rate_hz=8000).render(
+        timeline=timeline,
+        clips=clips,
+        bed_wav=_wave([1000] * 1600),
+        duck_bed=True,
+    )
+    bed = parse_wav(result.stems.stems["ambience"])[0]
+    assert 250 <= bed[799] <= 252
+    assert 374 <= bed[800] <= 376
+    assert bed[1599] > bed[800]
+
+
+def test_valid_fractional_selection_and_source_reuse():
+    timeline = Timeline(
+        cues=(
+            _cue(in_point_seconds=0.0002, out_point_seconds=0.0007),
+            _cue("b", 0.001, in_point_seconds=0.0005),
+        )
+    )
+    source = _wave(range(100, 110))
+    result = MixRenderer(sample_rate_hz=8000).render(
+        timeline=timeline,
+        clips=(MixClip("a", source), MixClip("b", source)),
+    )
+    assert list(parse_wav(result.master_wav)[0]) == [102, 103, 104, 105, 0, 0, 0, 0, 104, 105, 106, 107, 108, 109, 0, 0]
+
+
+def test_silent_source_selection_is_rejected():
+    cue = Cue(
+        cue_id="quiet",
+        source_ref="silence",
+        start_seconds=0,
+        duration_seconds=0.1,
+        kind=CueKind.SILENCE,
+        in_point_seconds=0,
+    )
+    with pytest.raises(MixError, match="silent cues"):
+        MixRenderer(sample_rate_hz=8000).render(timeline=Timeline(cues=(cue,)), clips=())
+
+
+def test_crossfade_uses_selected_sources_without_leading_sentinels():
+    timeline = Timeline(
+        cues=(
+            _cue(in_point_seconds=0.0005, out_point_seconds=0.002),
+            _cue("b", 0.001, in_point_seconds=0.0005, out_point_seconds=0.002),
+        )
+    )
+    result = MixRenderer(sample_rate_hz=8000).render(
+        timeline=timeline,
+        clips=(MixClip("a", _wave([999] * 4 + [200] * 12)), MixClip("b", _wave([888] * 4 + [-100] * 12))),
+        transitions=(CrossfadeTransition("a", "b", 0.0005),),
+    )
+    assert list(parse_wav(result.master_wav)[0]) == [200] * 8 + [200, 125, 50, -25] + [-100] * 4
+    assert [(w.in_sample, w.out_sample) for w in result.source_windows] == [(4, 16), (4, 16)]

--- a/tests/test_sound_source_windows_public.py
+++ b/tests/test_sound_source_windows_public.py
@@ -1,0 +1,94 @@
+"""Source windows and combined ambience through actual public transports."""
+
+from array import array
+import asyncio
+import hashlib
+import json
+import subprocess
+import sys
+import zipfile
+
+from kinocut import Client
+from kinocut_sound.mix._wav import parse_wav, pcm_to_wav
+from tests.test_sound_public_mix import mix_project  # noqa: F401 - shared real fixture
+
+
+def _inspect(root, result):
+    path = root / result["output_path"]
+    assert result["output_sha256"] == "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    with zipfile.ZipFile(path) as archive:
+        receipt = json.loads(archive.read("receipt.json"))
+        pcm, rate = parse_wav(archive.read("master.wav"))
+        for name, metadata in receipt["media"].items():
+            data = archive.read(name)
+            assert metadata["sha256"] == "sha256:" + hashlib.sha256(data).hexdigest()
+    assert pcm[0] == 310
+    assert pcm[2204] == 2514
+    assert pcm[2205] == 100  # Selected source exhausted; only bed remains.
+    assert pcm[4410] == -5900  # Ambience clip plus bed, never overwritten.
+    assert not any(pcm[8820:])
+    assert rate == 22050
+    assert receipt["source_windows"][0] == {
+        "cue_id": "a",
+        "in_sample": 220,
+        "out_sample": 2425,
+        "sample_count": 2205,
+        "sample_rate_hz": rate,
+    }
+    return pcm
+
+
+def test_real_public_trim_and_additive_bed_parity(mix_project):  # noqa: F811 - pytest injects imported fixture
+    root, request = mix_project
+    data = pcm_to_wav(array("h", range(-10, 6605)), sample_rate_hz=22050)
+    (root / "a.wav").write_bytes(data)
+    request["clips"][0]["sha256"] = "sha256:" + hashlib.sha256(data).hexdigest()
+    request["clips"][0]["stem_id"] = "ambience"
+    request["clips"][1]["stem_id"] = "ambience"
+    cue = request["plan"]["timeline"]["cues"][0]
+    cue.update(in_point_seconds=220 / 22050, out_point_seconds=2425 / 22050)
+    request["transitions"] = []
+    bed = pcm_to_wav(array("h", [100] * 8820), sample_rate_hz=22050)
+    (root / "bed.wav").write_bytes(bed)
+    request["bed"] = {"path": "bed.wav", "sha256": "sha256:" + hashlib.sha256(bed).hexdigest()}
+    request["plan"]["beds"] = ["bed.wav"]
+    request["duck_bed"] = True
+    expected = _inspect(root, Client().sound_mix_render(request, str(root)))
+    request["output_path"] = "cli.zip"
+    path = root / "request.json"
+    path.write_text(json.dumps(request))
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kinocut",
+            "--format",
+            "json",
+            "sound-mix-render",
+            "--request-json",
+            str(path),
+            "--project-root",
+            str(root),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=45,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert _inspect(root, json.loads(completed.stdout)) == expected
+    request["output_path"] = "mcp.zip"
+    result = asyncio.run(asyncio.wait_for(_mcp(root, request), timeout=45))
+    assert _inspect(root, result) == expected
+
+
+async def _mcp(root, request):
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    params = StdioServerParameters(command=sys.executable, args=["-m", "kinocut"])
+    async with stdio_client(params) as (read, write), ClientSession(read, write) as session:
+        await session.initialize()
+        response = await session.call_tool("sound_mix_render", {"request": request, "project_root": str(root)})
+        assert not response.isError
+        payload = response.structuredContent or json.loads(response.content[0].text)
+        return payload.get("result", payload)


### PR DESCRIPTION
Source in/out points were rejected by public mixing and ignored by direct rendering. The renderer now selects the requested PCM window once before placement and crossfades, preserving the timeline's padding and tail. Explicit out-of-range or empty selections fail; crossfades cannot consume post-roll beyond the selected out-point. Receipts record realized sample windows while retaining hashes of the original complete sources.

Ducked beds now add to the ambience stem instead of replacing its existing clips. PCM16 saturation and the existing ducking behavior remain covered by sample-level tests. Python, CLI and actual MCP calls produce matching decoded audio and verifiable receipts. Existing untrimmed requests and SoundPlan identities remain compatible.

Independent architecture and source review approved. Full integrated regression: 5,739 passed, 176 skipped. Validation also includes 107 focused tests, a retained positive trimmed-crossfade regression, and 26 combined speech/public-source-window tests. Whole lint/format and compatibility checks passed. Hosted PR and master gates remain to run. Stereo, routing, effects, layers and mastering remain separate work.
