### PR TITLE
fix: validate complete sound tokens and export paths

### DIFF
--- a/docs/SOUND_INPUT_VALIDATION.md
+++ b/docs/SOUND_INPUT_VALIDATION.md
@@ -6,6 +6,17 @@ targets, voice modifiers, cost estimates, adapter timeouts and profile versions.
 `true` and `false` remain valid for actual boolean flags such as mute, solo and
 human-review requirements.
 
+Whole-field codes, territories, regions, locales, advisory text and timestamp
+validators reject trailing control characters as well as embedded ones. Clone
+and blend export paths are checked as complete paths before authorization or
+rendering. Invalid input is rejected, never silently stripped into another identity.
+Optional values and valid canonical hashes are unchanged.
+
+Prefix parsers such as FFmpeg version extraction retain their existing behavior.
+The existing Pydantic digest, record-kind and creator patterns already reject
+trailing controls; their published schema patterns remain unchanged. Timestamp
+calendar semantics and authorization error codes are preserved.
+
 The checked guard inventory and compatibility controls are retained in
 `tests/fixtures/sound_numeric_guard_inventory.json` and
 `tests/fixtures/sound_numeric_baseline.json`. They cover the existing numeric
@@ -44,4 +55,3 @@ silently ignore an alias when the primary plan is None.
 
 Python, CLI and MCP share these checks. CLI validation errors retain the existing
 nonzero exit and stderr message behavior; they do not emit a successful plan result.
-

--- a/kinocut_sound/_canonical.py
+++ b/kinocut_sound/_canonical.py
@@ -93,7 +93,7 @@ def BoundedCode(value: str) -> str:
     ``BeforeValidator`` or called directly from a contract module.
     """
 
-    if not CODE_RE.match(value):
+    if not CODE_RE.fullmatch(value):
         raise ValueError("value must be a bounded code (no spaces, paths, URLs, or prose)")
     return value
 

--- a/kinocut_sound/authorization.py
+++ b/kinocut_sound/authorization.py
@@ -151,7 +151,7 @@ def _authorization_error(message: str, code: str) -> AuthorizationError:
 
 
 def _parse_time(value: str) -> datetime:
-    if not ISO8601_RE.match(value):
+    if not ISO8601_RE.fullmatch(value):
         raise _authorization_error("invalid authorization timestamp", "invalid_timestamp")
     try:
         return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)

--- a/kinocut_sound/capability.py
+++ b/kinocut_sound/capability.py
@@ -61,7 +61,7 @@ class CostDisclosure(FrozenModel):
     @field_validator("region")
     @classmethod
     def _region_bounded(cls, value: str) -> str:
-        if not REGION_RE.match(value):
+        if not REGION_RE.fullmatch(value):
             raise ValueError("region must be a bounded code (no spaces or paths)")
         return value
 
@@ -152,7 +152,7 @@ class CapabilityResult(FrozenModel):
     @field_validator("remediation")
     @classmethod
     def _remediation_advisory(cls, value: str | None) -> str | None:
-        if value is not None and not ADVISORY_RE.match(value):
+        if value is not None and not ADVISORY_RE.fullmatch(value):
             raise ValueError("remediation must be short and free of paths, URLs, or metacharacters")
         return value
 

--- a/kinocut_sound/consent.py
+++ b/kinocut_sound/consent.py
@@ -70,7 +70,7 @@ class ConsentScope(FrozenModel):
     @classmethod
     def _territory_is_bounded(cls, value: str) -> str:
         # Territory is a short UN M49 / ISO 3166-style code; letters/digits only.
-        if not TERRITORY_RE.match(value):
+        if not TERRITORY_RE.fullmatch(value):
             raise ValueError("territory must be a bounded code (2-16 alphanumeric chars)")
         return value
 
@@ -79,7 +79,7 @@ class ConsentScope(FrozenModel):
     def _use_summary_is_advisory(cls, value: str | None) -> str | None:
         if value is None:
             return value
-        if not ADVISORY_RE.match(value):
+        if not ADVISORY_RE.fullmatch(value):
             raise ValueError("intended_use_summary must be short and free of paths, URLs, or metacharacters")
         return value
 
@@ -99,7 +99,7 @@ class AuditEvent(FrozenModel):
     @field_validator("at_iso")
     @classmethod
     def _iso8601(cls, value: str) -> str:
-        if not ISO8601_RE.match(value):
+        if not ISO8601_RE.fullmatch(value):
             raise ValueError("at_iso must be a UTC ISO-8601 timestamp (YYYY-MM-DDTHH:MM:SSZ)")
         return value
 
@@ -130,7 +130,7 @@ class CloudEgressGrant(FrozenModel):
     @field_validator("territory")
     @classmethod
     def _territory_bounded(cls, value: str) -> str:
-        if not TERRITORY_RE.match(value):
+        if not TERRITORY_RE.fullmatch(value):
             raise ValueError("territory must be a bounded code (2-16 alphanumeric chars)")
         return value
 
@@ -144,7 +144,7 @@ class CloudEgressGrant(FrozenModel):
     @field_validator("expiry_iso")
     @classmethod
     def _expiry_iso8601(cls, value: str) -> str:
-        if not ISO8601_RE.match(value):
+        if not ISO8601_RE.fullmatch(value):
             raise ValueError("expiry_iso must be a UTC ISO-8601 timestamp")
         return value
 
@@ -202,7 +202,7 @@ class ConsentGrant(FrozenModel):
     @field_validator("issue_iso", "expiry_iso")
     @classmethod
     def _iso8601(cls, value: str) -> str:
-        if not ISO8601_RE.match(value):
+        if not ISO8601_RE.fullmatch(value):
             raise ValueError("timestamps must be UTC ISO-8601 (YYYY-MM-DDTHH:MM:SSZ)")
         return value
 

--- a/kinocut_sound/provider_policy.py
+++ b/kinocut_sound/provider_policy.py
@@ -281,14 +281,14 @@ class ProviderRequest(FrozenModel):
     @field_validator("territory")
     @classmethod
     def _territory(cls, value: str) -> str:
-        if not TERRITORY_RE.match(value):
+        if not TERRITORY_RE.fullmatch(value):
             raise ValueError("territory must be bounded")
         return value
 
     @field_validator("at_iso")
     @classmethod
     def _timestamp(cls, value: str) -> str:
-        if not ISO8601_RE.match(value):
+        if not ISO8601_RE.fullmatch(value):
             raise ValueError("at_iso must be UTC ISO-8601")
         return value
 
@@ -335,7 +335,7 @@ class CloudExecutionApproval(FrozenModel):
     @field_validator("territory")
     @classmethod
     def _territory(cls, value: str) -> str:
-        if not TERRITORY_RE.match(value):
+        if not TERRITORY_RE.fullmatch(value):
             raise ValueError("territory must be bounded")
         return value
 
@@ -415,7 +415,7 @@ def _sanitize_context(value: object) -> AuthorizationContext:
         "provider_class": value.provider_class,
     }
     checked = {name: BoundedCode(item) if item is not None else None for name, item in codes.items()}
-    if value.territory is not None and not TERRITORY_RE.match(value.territory):
+    if value.territory is not None and not TERRITORY_RE.fullmatch(value.territory):
         raise ValueError("authorization territory is invalid")
     return AuthorizationContext(**checked, territory=value.territory)
 

--- a/kinocut_sound/render_fingerprint.py
+++ b/kinocut_sound/render_fingerprint.py
@@ -76,7 +76,7 @@ class RenderFingerprint(FrozenModel):
     @field_validator("locale")
     @classmethod
     def _locale_bounded(cls, value: str) -> str:
-        if not LOCALE_RE.match(value):
+        if not LOCALE_RE.fullmatch(value):
             raise ValueError("locale must be a bounded identifier (no spaces or paths)")
         return value
 

--- a/kinocut_sound/voice/blend.py
+++ b/kinocut_sound/voice/blend.py
@@ -310,7 +310,7 @@ class BlendRenderer:
         context: AuthorizationContext,
         at_iso: str,
     ) -> str:
-        if not isinstance(output_path, str) or not _SAFE_REL_PATH.match(output_path):
+        if not isinstance(output_path, str) or not _SAFE_REL_PATH.fullmatch(output_path):
             raise voice_error(
                 "blend export path must be a safe project-relative path",
                 ADAPTER_INPUT_INVALID,

--- a/kinocut_sound/voice/clone.py
+++ b/kinocut_sound/voice/clone.py
@@ -167,7 +167,7 @@ class CloneRenderer:
         context: AuthorizationContext,
         at_iso: str,
     ) -> str:
-        if not isinstance(output_path, str) or not _SAFE_REL_PATH.match(output_path):
+        if not isinstance(output_path, str) or not _SAFE_REL_PATH.fullmatch(output_path):
             raise voice_error(
                 "clone export path must be a safe project-relative path",
                 ADAPTER_INPUT_INVALID,

--- a/kinocut_sound/voice/roster.py
+++ b/kinocut_sound/voice/roster.py
@@ -110,7 +110,7 @@ def _validate_slot(slot: VoiceSlot) -> VoiceSlot:
             "voice slot id must be a bounded code",
             ROSTER_INVALID,
         ) from exc
-    if not CODE_RE.match(slot.display_label):
+    if not CODE_RE.fullmatch(slot.display_label):
         raise voice_error(
             "voice slot display label must be a bounded code",
             ROSTER_INVALID,

--- a/tests/test_sound_whole_field_compatibility.py
+++ b/tests/test_sound_whole_field_compatibility.py
@@ -1,0 +1,103 @@
+"""Strict field boundaries preserve valid values, schema patterns and archives."""
+
+from array import array
+import hashlib
+from types import SimpleNamespace
+import pytest
+
+from kinocut_sound._canonical import BoundedCode, RecordBase
+from kinocut_sound.public.mix_request import SourceAsset, load_mix_request
+from kinocut_sound.qa.meter import _version
+from kinocut_sound.validation import SHA256_PATTERN, RECORD_KIND_PATTERN, CREATED_BY_PATTERN
+from kinocut_sound.voice.clone import CloneRenderer
+from kinocut_sound.voice.blend import BlendRenderer
+from kinocut_sound.mix._wav import pcm_to_wav
+from tests.test_sound_public_mix import mix_project, _render  # noqa: F401
+from tests.test_sound_static_routing import routed_project, make_stereo  # noqa: F401
+from tests.test_sound_rate_conversion_public import converted_project
+from tests.test_sound_rate_conversion_composition import converted_layers
+
+
+@pytest.mark.parametrize("value", ["a", "A_1:valid.code-2", "a" * 64])
+def test_valid_codes_are_not_normalized(value):
+    assert BoundedCode(value) == value
+
+
+def test_code_length_and_prefix_parsers_remain_correct():
+    with pytest.raises(ValueError):
+        BoundedCode("a" * 65)
+    assert _version(b"ffmpeg version 8.1 Copyright (c) FFmpeg developers\nconfiguration: flags") == "8.1"
+
+
+def test_published_pattern_strings_are_unchanged():
+    record = RecordBase.model_json_schema()["properties"]
+    source = SourceAsset.model_json_schema()["properties"]
+    assert source["sha256"]["pattern"] == SHA256_PATTERN == r"^sha256:[0-9a-f]{64}$"
+    assert record["record_kind"]["pattern"] == RECORD_KIND_PATTERN == r"^[a-z][a-z0-9_]{0,63}$"
+    assert record["created_by"]["pattern"] == CREATED_BY_PATTERN == r"^(human|agent|tool)(:[a-z0-9][a-z0-9_.-]{0,63})?$"
+
+
+@pytest.mark.parametrize("renderer", [CloneRenderer, BlendRenderer])
+@pytest.mark.parametrize("path", ["voice.wav", "exports/voice-1.wav"])
+def test_valid_export_paths_reach_authorization(renderer, path):
+    class ReachedAuthorization(Exception):
+        pass
+
+    def reached(**kwargs):
+        raise ReachedAuthorization
+
+    sentinel = SimpleNamespace(_authorize_export=reached, _authorize=reached)
+    with pytest.raises(ReachedAuthorization):
+        renderer.export(
+            sentinel,
+            output_path=path,
+            output_dir="unused",
+            line=None,
+            profile=None,
+            ledger=None,
+            context=None,
+            at_iso="2026-01-01T00:00:00Z",
+        )
+
+
+@pytest.mark.parametrize(
+    "layered,stereo,request_hash,archive_hash",
+    [
+        (
+            False,
+            False,
+            "3c112105629a2eef8f332e328c8cec643857e092727ba327542d5c660856b954",
+            "763945f2bd960fd0c27f65ba8eb4c405bb98a8c214f68b5b0269e987c983b8fa",
+        ),
+        (
+            False,
+            True,
+            "4b1efdd7b9d13c6fe0fd8474fb56bf270e8966d155e9bcc2b8af66c0cf9618ae",
+            "ffadb495b7f315175f5a45ea1498ffa3141f5088db695bbaff57dc9f428ba3d4",
+        ),
+        (
+            True,
+            False,
+            "ea37195b9811807e54ede956c2e2093e8d2688dac7787d39a70f8320c70797bb",
+            "57ff7879964e9cfaa518be52c5a56428924ea38ee981ddd731546d2fef5a989c",
+        ),
+        (
+            True,
+            True,
+            "dadd4177b461ce446d7a702c5d063cec20c62b78408e0ef29549b263d597aac1",
+            "d79637956bdf1c2ba1068913a0282164143d6d5fe82b0c6d9aad191cc1872d9b",
+        ),
+    ],
+)
+def test_valid_v4_copy_archives_remain_exact(routed_project, layered, stereo, request_hash, archive_hash):  # noqa: F811
+    root, request = (converted_layers if layered else converted_project).__wrapped__(routed_project)
+    request["plan"]["format"]["sample_rate_hz"] = 22050
+    if stereo:
+        make_stereo(root, request)
+        if layered:
+            data = pcm_to_wav(array("h", [10000, -5000] * 2205), sample_rate_hz=22050, channel_count=2)
+            (root / "layer.wav").write_bytes(data)
+            request["layer_assets"][0]["source"]["sha256"] = "sha256:" + hashlib.sha256(data).hexdigest()
+    assert load_mix_request(request).canonical_id() == "sha256:" + request_hash
+    result = _render(root, request)
+    assert result["converted_source_count"] == 0 and result["output_sha256"] == "sha256:" + archive_hash

--- a/tests/test_sound_whole_field_models.py
+++ b/tests/test_sound_whole_field_models.py
@@ -1,0 +1,162 @@
+"""Whole fields reject suffix controls without normalizing valid identities."""
+
+from dataclasses import replace
+from types import SimpleNamespace
+import pytest
+from pydantic import ValidationError
+
+from kinocut_sound._canonical import BoundedCode, RecordBase
+from kinocut_sound.authorization import AuthorizationContext, AuthorizationError, _parse_time
+from kinocut_sound.capability import CapabilityResult, CostDisclosure
+from kinocut_sound.consent import AuditEvent, CloudEgressGrant, ConsentGrant, ConsentScope, RetentionPolicy
+from kinocut_sound.provider_policy import _sanitize_context
+from kinocut_sound.render_fingerprint import FingerprintComponent, RenderFingerprint
+from kinocut_sound.public.mix_request import SourceAsset
+from kinocut_sound.routing import Track
+from kinocut_sound.timeline import Cue
+from kinocut_sound.world.layers import AmbientLayer
+from kinocut_sound.voice.roster import _BASE_ROSTER, _validate_slot
+from kinocut_sound.voice._errors import VoiceError
+from kinocut_sound.voice.clone import CloneRenderer
+from kinocut_sound.voice.blend import BlendRenderer
+from tests.test_kinocut_sound_s3_policy import _request
+from tests.test_kinocut_sound_s3_review import _approved_cloud
+
+SHA = "sha256:" + "a" * 64
+NOW = "2026-01-01T00:00:00Z"
+CONTROLS = ("\n", "\r\n", "\r", "\t", "\0", "\u2028")
+
+
+def _cases():
+    scope = ConsentScope(territory="US", intended_use_summary="A short preview.")
+    grant = ConsentGrant(
+        grant_id="grant",
+        subject_id="subject",
+        rightsholder_id="owner",
+        scope=scope,
+        reference_evidence_hash=SHA,
+        transcript_evidence_hash=SHA,
+        reviewer_id="reviewer",
+        issue_iso=NOW,
+        expiry_iso="2027-01-01T00:00:00Z",
+        state="live",
+        retention=RetentionPolicy(biometric_retention="delete", audit_retention="retain"),
+    )
+    cloud = CloudEgressGrant(
+        provider_id="provider", data_classes=("audio",), territory="US", retention_ceiling_days=0, expiry_iso=NOW
+    )
+    cost = CostDisclosure(
+        provider_id="provider",
+        region="us-east-1",
+        data_classes=("audio",),
+        retention_ceiling_days=0,
+        estimated_cost_usd_per_call=0,
+        confirmed=False,
+    )
+    fingerprint = RenderFingerprint(
+        determinism_class="byte_deterministic",
+        seed="0",
+        locale="en_US",
+        hardware_backend="cpu",
+        concurrency_ordering="serial",
+        components=(FingerprintComponent(role="plan", digest=SHA),),
+    )
+    return [
+        (scope, "territory"),
+        (scope, "intended_use_summary"),
+        (AuditEvent(event="issued", actor="human", at_iso=NOW), "at_iso"),
+        (cloud, "territory"),
+        (cloud, "expiry_iso"),
+        (grant, "issue_iso"),
+        (grant, "expiry_iso"),
+        (cost, "region"),
+        (
+            CapabilityResult(
+                adapter_id="local", available=False, reason_code="missing", remediation="Install optional tools."
+            ),
+            "remediation",
+        ),
+        (fingerprint, "locale"),
+        (Cue(cue_id="cue", source_ref="clip.wav", start_seconds=0, duration_seconds=1, kind="line"), "cue_id"),
+        (
+            Track(
+                track_id="track", destination_bus_id="dialogue", pan_law="linear", gain_db=0, muted=False, soloed=False
+            ),
+            "track_id",
+        ),
+        (AmbientLayer(layer_id="layer", asset_ref="rain"), "layer_id"),
+        (_request(), "territory"),
+        (_request(), "at_iso"),
+        (_approved_cloud()[1], "territory"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "model,field", _cases(), ids=lambda item: type(item).__name__ if not isinstance(item, str) else item
+)
+@pytest.mark.parametrize("suffix", CONTROLS)
+def test_model_fields_reject_suffix_controls(model, field, suffix):
+    raw = model.model_dump(mode="python")
+    assert type(model).model_validate(raw).model_dump(mode="python") == raw
+    raw[field] += suffix
+    with pytest.raises(ValidationError):
+        type(model).model_validate(raw)
+
+
+@pytest.mark.parametrize("suffix", CONTROLS)
+def test_shared_codes_and_roster_labels_reject_controls(suffix):
+    with pytest.raises(ValueError):
+        BoundedCode("cue-a" + suffix)
+    slot = _BASE_ROSTER[0]
+    with pytest.raises(VoiceError):
+        _validate_slot(replace(slot, display_label=slot.display_label + suffix))
+
+
+@pytest.mark.parametrize("suffix", CONTROLS)
+def test_authorization_timestamp_keeps_error_contract(suffix):
+    with pytest.raises(AuthorizationError) as error:
+        _parse_time(NOW + suffix)
+    assert error.value.code == "invalid_timestamp"
+
+
+@pytest.mark.parametrize("suffix", CONTROLS)
+def test_authorization_context_whole_territory(suffix):
+    context = AuthorizationContext(operation="generate", territory="US" + suffix)
+    with pytest.raises(ValueError):
+        _sanitize_context(context)
+
+
+@pytest.mark.parametrize(
+    "model,base,field",
+    [
+        (SourceAsset, {"path": "clip.wav", "sha256": SHA}, "sha256"),
+        (RecordBase, {"record_kind": "line", "project_id": "demo", "created_by": "human"}, "record_kind"),
+        (RecordBase, {"record_kind": "line", "project_id": "demo", "created_by": "human"}, "created_by"),
+    ],
+)
+@pytest.mark.parametrize("suffix", CONTROLS)
+def test_pydantic_patterns_remain_strict(model, base, field, suffix):
+    model(**base)
+    with pytest.raises(ValidationError) as error:
+        model(**{**base, field: base[field] + suffix})
+    assert any(item["type"] == "string_pattern_mismatch" for item in error.value.errors())
+
+
+@pytest.mark.parametrize("renderer", [CloneRenderer, BlendRenderer])
+@pytest.mark.parametrize("suffix", CONTROLS)
+def test_export_path_rejects_controls_before_authorization(renderer, suffix):
+    def forbidden(**kwargs):
+        raise AssertionError("bad path reached authorization")
+
+    sentinel = SimpleNamespace(_authorize_export=forbidden, _authorize=forbidden)
+    with pytest.raises(VoiceError):
+        renderer.export(
+            sentinel,
+            output_path="voice.wav" + suffix,
+            output_dir="unused",
+            line=None,
+            profile=None,
+            ledger=None,
+            context=None,
+            at_iso=NOW,
+        )


### PR DESCRIPTION
Several sound validators accepted a final newline because Python regex `$` can match before it. Whole-field codes, territories, advisory text, timestamps, regions, locales, roster labels and clone/blend export paths now use `fullmatch`, rejecting the malformed value without stripping it into a different identity.

Intentional prefix parsers, published schema patterns, valid canonical values and authorization error behavior remain unchanged. Export-path checks still precede authorization; tests use sentinels and perform no generation or export.

Validation: independent source and claims reviews approved. Seventeen old-code failures were reproduced, with additional provider-model probes confirming the defect. The focused suite passed 157 tests and the broad sound suite passed 1,996. Controls cover actual models, strict Pydantic patterns, parser behavior and four new V4 same-rate archive baselines alongside existing compatibility tests. Scoped lint, formatting, import, size and leak checks passed. Required full suite: 6,969 passed, 176 skipped, 8 warnings.
