### PR TITLE
ci: move full candidate validation to hosted runners

### DIFF
--- a/.github/workflows/pr-safety.yml
+++ b/.github/workflows/pr-safety.yml
@@ -4,15 +4,24 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-safety-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   hosted-pr-checks:
     name: Hosted PR checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
       - id: classify
         name: Classify changes
         shell: bash
@@ -30,17 +39,18 @@ jobs:
       - name: Skip hosted checks
         if: steps.classify.outputs.code != 'true'
         run: echo "Code inputs unchanged; marking hosted PR checks successful."
-      - name: Install FFmpeg
+      - name: Install media backends
         if: steps.classify.outputs.code == 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ffmpeg
+          sudo apt-get install -y --no-install-recommends ffmpeg espeak-ng
           ffmpeg -version
           ffprobe -version
+          espeak-ng --version
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         if: steps.classify.outputs.code == 'true'
         with:
-          python-version: "3.14"
+          python-version: "3.13"
       - name: Install package
         if: steps.classify.outputs.code == 'true'
         # ruff pinned to the same version as the CI lint job so the hosted PR
@@ -51,6 +61,72 @@ jobs:
         run: |
           ruff check kinocut/ kinocut_sound/ mcp_video.py tests/
           ruff format --check kinocut/ kinocut_sound/ mcp_video.py tests/
-      - name: Test
+      - name: Record candidate and runtime
         if: steps.classify.outputs.code == 'true'
-        run: pytest tests/ -q -m "not slow" --tb=short
+        env:
+          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
+          VALIDATION_EVIDENCE_DIR: ${{ runner.temp }}/candidate-validation
+        run: |
+          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"
+          echo "VALIDATION_EVIDENCE_DIR=$VALIDATION_EVIDENCE_DIR" >> "$GITHUB_ENV"
+          mkdir -p "$VALIDATION_EVIDENCE_DIR"
+          git rev-parse HEAD > "$VALIDATION_EVIDENCE_DIR/source-sha.txt"
+          python3 --version > "$VALIDATION_EVIDENCE_DIR/python-version.txt"
+          ffmpeg -version > "$VALIDATION_EVIDENCE_DIR/ffmpeg-version.txt"
+          ffprobe -version > "$VALIDATION_EVIDENCE_DIR/ffprobe-version.txt"
+          espeak-ng --version > "$VALIDATION_EVIDENCE_DIR/espeak-version.txt"
+          python3 -c "import kinocut, mcp_video; assert kinocut.Client is mcp_video.Client"
+      - name: Full candidate suite
+        id: full-suite
+        if: steps.classify.outputs.code == 'true'
+        run: |
+          set +e
+          python3 -m pytest tests/ -x -q --tb=short --junitxml="$VALIDATION_EVIDENCE_DIR/tests.xml"
+          result=$?
+          echo "$result" > "$VALIDATION_EVIDENCE_DIR/pytest-exit.txt"
+          exit "$result"
+      - name: Verify required media scenarios and summarize skips
+        if: always() && steps.classify.outputs.code == 'true'
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import xml.etree.ElementTree as ET
+          from pathlib import Path
+
+          evidence = Path(os.environ["VALIDATION_EVIDENCE_DIR"])
+          cases = list(ET.parse(evidence / "tests.xml").iter("testcase"))
+          required = (
+              "test_sound_dub_render",
+              "test_sound_speech_spatial_public",
+              "test_sound_speech_spatial_transports",
+              "test_sound_speech_spatial_dsp",
+              "test_sound_rate_conversion_public",
+          )
+          missing = []
+          for module in required:
+              selected = [case for case in cases if case.get("classname", "").split(".")[-1] == module]
+              if not selected or any(case.find(tag) is not None for case in selected for tag in ("skipped", "failure", "error")):
+                  missing.append(module)
+          summary = {
+              "source_sha": (evidence / "source-sha.txt").read_text().strip(),
+              "command": "python3 -m pytest tests/ -x -q --tb=short --junitxml=<evidence>/tests.xml",
+              "pytest_exit": int((evidence / "pytest-exit.txt").read_text()),
+              "test_cases": len(cases),
+              "failures": sum(case.find("failure") is not None or case.find("error") is not None for case in cases),
+              "skipped": [case.get("classname", "") + "::" + case.get("name", "") for case in cases if case.find("skipped") is not None],
+              "required_media_not_passed": missing,
+              "cached_model_asr": "requires separate assigned-host evidence when changed; no model downloads",
+          }
+          (evidence / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+          if not cases or summary["pytest_exit"] != 0 or summary["failures"] or missing:
+              raise SystemExit("Full suite or required media evidence did not pass")
+          PY
+      - name: Retain candidate validation evidence
+        if: always() && steps.classify.outputs.code == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: candidate-validation-${{ github.event.pull_request.head.sha }}
+          path: ${{ runner.temp }}/candidate-validation/
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/pr-safety.yml
+++ b/.github/workflows/pr-safety.yml
@@ -76,6 +76,14 @@ jobs:
           ffprobe -version > "$VALIDATION_EVIDENCE_DIR/ffprobe-version.txt"
           espeak-ng --version > "$VALIDATION_EVIDENCE_DIR/espeak-version.txt"
           python3 -c "import kinocut, mcp_video; assert kinocut.Client is mcp_video.Client"
+      - name: Verify candidate identity and quality boundaries
+        if: steps.classify.outputs.code == 'true'
+        run: |
+          python3 -m pytest -q --tb=short \
+            tests/test_golden_path.py::test_spoofed_github_sha_and_unavailable_git_fail \
+            tests/test_golden_path.py::test_confidence_workflow_commit_identity_is_exact \
+            tests/test_golden_path.py::test_confidence_workflow_stops_before_checkpoint_on_failed_raw_check \
+            --junitxml="$VALIDATION_EVIDENCE_DIR/identity-regressions.xml"
       - name: Full candidate suite
         id: full-suite
         if: steps.classify.outputs.code == 'true'

--- a/.github/workflows/pr-safety.yml
+++ b/.github/workflows/pr-safety.yml
@@ -43,10 +43,30 @@ jobs:
         if: steps.classify.outputs.code == 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ffmpeg espeak-ng
+          sudo apt-get install -y --no-install-recommends ffmpeg build-essential cmake ninja-build libsonic-dev
           ffmpeg -version
           ffprobe -version
-          espeak-ng --version
+      - name: Build pinned deterministic speech backend
+        if: steps.classify.outputs.code == 'true'
+        run: |
+          # Ubuntu 24.04 supplies 1.51, which does not implement the -D flag.
+          espeak_source="$RUNNER_TEMP/espeak-source"
+          espeak_build="$RUNNER_TEMP/espeak-build"
+          espeak_prefix="$RUNNER_TEMP/espeak-runtime"
+          git init "$espeak_source"
+          git -C "$espeak_source" remote add origin https://github.com/espeak-ng/espeak-ng.git
+          git -C "$espeak_source" fetch --depth 1 origin 4870adfa25b1a32b4361592f1be8a40337c58d6c
+          git -C "$espeak_source" checkout --detach FETCH_HEAD
+          test "$(git -C "$espeak_source" rev-parse HEAD)" = 4870adfa25b1a32b4361592f1be8a40337c58d6c
+          cmake -S "$espeak_source" -B "$espeak_build" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$espeak_prefix" \
+            -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF -DUSE_ASYNC=OFF \
+            -DUSE_MBROLA=OFF -DUSE_LIBPCAUDIO=OFF -DESPEAK_BUILD_MANPAGES=OFF
+          cmake --build "$espeak_build" --target espeak-ng data --parallel 2
+          cmake --install "$espeak_build"
+          "$espeak_prefix/bin/espeak-ng" --version
+          "$espeak_prefix/bin/espeak-ng" --help | grep -F 'Enable deterministic random mode'
+          echo "$espeak_prefix/bin" >> "$GITHUB_PATH"
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         if: steps.classify.outputs.code == 'true'
         with:
@@ -75,14 +95,20 @@ jobs:
           ffmpeg -version > "$VALIDATION_EVIDENCE_DIR/ffmpeg-version.txt"
           ffprobe -version > "$VALIDATION_EVIDENCE_DIR/ffprobe-version.txt"
           espeak-ng --version > "$VALIDATION_EVIDENCE_DIR/espeak-version.txt"
+          echo 4870adfa25b1a32b4361592f1be8a40337c58d6c > "$VALIDATION_EVIDENCE_DIR/espeak-source-sha.txt"
           python3 -c "import kinocut, mcp_video; assert kinocut.Client is mcp_video.Client"
-      - name: Verify candidate identity and quality boundaries
+      - name: Verify candidate identity and required media
         if: steps.classify.outputs.code == 'true'
         run: |
           python3 -m pytest -q --tb=short \
             tests/test_golden_path.py::test_spoofed_github_sha_and_unavailable_git_fail \
             tests/test_golden_path.py::test_confidence_workflow_commit_identity_is_exact \
             tests/test_golden_path.py::test_confidence_workflow_stops_before_checkpoint_on_failed_raw_check \
+            tests/test_sound_dub_render.py \
+            tests/test_sound_speech_spatial_public.py \
+            tests/test_sound_speech_spatial_transports.py \
+            tests/test_sound_speech_spatial_dsp.py \
+            tests/test_sound_rate_conversion_public.py \
             --junitxml="$VALIDATION_EVIDENCE_DIR/identity-regressions.xml"
       - name: Full candidate suite
         id: full-suite

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,8 +92,21 @@ the user an unexplained approval gate.
 
 ## Testing
 
-20. **Every fix must pass `python3 -m pytest tests/ -x -q --tb=short`** before committing.
-21. **Run `python3 -c "import kinocut, mcp_video; assert kinocut.Client is mcp_video.Client"`** to verify the canonical import and compatibility shim after changes.
+20. **Every code fix must pass the full suite before merge:** `python3 -m pytest tests/ -x -q --tb=short`. Draft commits and PRs may be created to obtain hosted validation; they are candidates, not verified releases. The hosted PR job runs the full suite, including slow tests, against the candidate head. Reconcile its recorded source SHA with the reviewed head before merging.
+21. **Verify the canonical import and compatibility shim in that validation job:** `python3 -c "import kinocut, mcp_video; assert kinocut.Client is mcp_video.Client"`.
+
+- Use existing hosted runners for heavy tests, renders and builds. Keep a constrained
+  coordination machine to light editing, review and CI coordination. A capacity
+  hold overrides local test recipes and serialization locks; do not start heavy
+  local work, add workers or choose another fleet host without placement authority.
+- Run targeted reproductions where needed, then comprehensive validation on the
+  frozen candidate. Do not duplicate full local and hosted suites by default or
+  repeat unchanged successful checks without a specific unresolved concern.
+- Retain source SHA, runtime versions, command, exit status and test/skip evidence.
+  Failed, cancelled, missing or skipped required scenarios are not passes. Changes
+  to cached-model ASR require real recognition evidence on an assigned host with
+  the existing runtime and cache before merge; contract tests alone do not suffice.
+  Do not download models or use the coordination host to erase this gap.
 
 <!-- EMPOWER_ORCHESTRATOR:START -->
 ## Empower Orchestrator law

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,8 +102,15 @@ tests/
 - Every new tool needs at least: success case, error case (bad input), and one edge case
 - Add adversarial tests in `test_adversarial_audit.py` for any new validation
 - E2E tests chain multiple operations together
-- Run the full suite before pushing: `pytest tests/ -v -m "not slow" --tb=short`
-- Keep the default non-slow suite green, and run slower or environment-sensitive coverage when your change touches those surfaces
+- Draft commits and PRs may be pushed for hosted validation. Before merge, the
+  candidate must pass `python3 -m pytest tests/ -x -q --tb=short`, including slow
+  tests, in the hosted PR job. Check that its evidence matches the reviewed head.
+- Heavy validation belongs on existing hosted runners when the coordination
+  machine is capacity-constrained. Do not duplicate a successful hosted full suite
+  locally by default. Local capacity holds take precedence over test recipes.
+- Review the retained runtime and skip evidence. Required backend scenarios must
+  actually run. Cached-model ASR changes need real recognition validation on an
+  assigned host with the existing cache before merge; CI does not download models.
 
 ### Automated tests vs manual scripts
 

--- a/tests/test_golden_path.py
+++ b/tests/test_golden_path.py
@@ -274,6 +274,8 @@ def test_synthetic_generators_execute_the_same_shared_recipe(tmp_path: Path, mon
 def test_confidence_workflow_stops_before_checkpoint_on_failed_raw_check(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    # This test targets raw quality; CI merge-SHA mismatch has separate coverage.
+    monkeypatch.delenv("GITHUB_SHA", raising=False)
     source = tmp_path / "source.mp4"
     source.write_bytes(b"source")
 


### PR DESCRIPTION
The previous process required full local tests before a commit while PR CI ran only non-slow tests. This duplicated heavy work and made a capacity-constrained coordination machine a prerequisite for delivery.

Allow draft commits and PRs to obtain hosted validation, while retaining the full-suite requirement before merge. The hosted PR check now uses the submitted head, Python 3.13, FFmpeg and eSpeak, runs the complete suite including slow tests, and retains source/runtime/JUnit/exit evidence. Required real speech and rate-conversion scenarios must be present and pass without skips. The runner is explicitly hosted with read-only repository permissions and a bounded timeout.

Agent and contributor instructions now honor capacity holds, avoid duplicate full local/hosted validation, and require separate real cached-model ASR evidence when affected. No model downloads, fleet placement, repository protection changes or blanket skip waivers are introduced.

Validation so far: actionlint; YAML, shell and inline Python syntax; six synthetic receipt checks covering success, skipped/missing required coverage, unrelated failures, nonzero exit and empty results. Comprehensive validation will run in this PR's hosted job before merge.

The first hosted full run exposed an environment-dependent quality-check fixture: it inherited the PR merge SHA while the candidate head was checked out. Isolate that fixture from the unrelated environment variable, preserving the production identity guard and its explicit mismatch regressions. The workflow runs those three identity/quality regressions before the full suite to surface this failure early.

Real speech coverage also exposed a runtime mismatch: Ubuntu's eSpeak 1.51 lacks the deterministic `-D` option. Build the upstream 1.52.0 commit in the hosted runner's temporary directory, verify the capability, and record its source identity. Required speech and conversion scenarios run before the full suite so backend failures surface promptly. No backend tests are disabled to make the gate pass.
